### PR TITLE
Fix dataclass field

### DIFF
--- a/recoverai_app.py
+++ b/recoverai_app.py
@@ -16,7 +16,7 @@ Key features
 from __future__ import annotations
 
 import os, time, re, random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional
 
 import streamlit as st
@@ -67,12 +67,12 @@ class AppCfg:
         "confidentiality. Respond with empathy, short sentences, and invite them to stay connected."
     )
 
-    USER_ERR: dict[str, str] = {
+    USER_ERR: dict[str, str] = field(default_factory=lambda: {
         "MISSING_KEY": "Please enter your OpenAI API key in the sidebar to continue.",
         "INVALID_KEY": "Your OpenAI API key appears invalid or was rejected. Please double-check it.",
         "RATE_LIMIT":  "OpenAI is rate-limiting right now. Please wait a few seconds and try again.",
         "GENERIC":     "I couldn’t reach OpenAI at the moment. Please check your connection and try again.",
-    }
+    })
 
 CFG = AppCfg()
 


### PR DESCRIPTION
## Summary
- fix `AppCfg` dataclass to use `field(default_factory=...)`
- ensure imports include `field`

## Testing
- `python3 recoverai_app.py`
- `streamlit run recoverai_app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_688be5eaadb0832c8c04ab820ab0373a